### PR TITLE
Add 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import Layout from '../../components/Layout';
+
+export default function NotFound() {
+  return (
+    <Layout>
+      <h2>Page Not Found</h2>
+      <p>Sorry, the page you requested could not be found.</p>
+      <p>
+        <Link href="/">Return Home</Link>
+      </p>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Next.js `not-found` page so invalid URLs render a friendly message

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6849f41b7248832ba4919ecc4fec25be